### PR TITLE
Fix various AOT compilation related issues

### DIFF
--- a/src/org/jetbrains/plugins/clojure/compiler/component/ClojureCompilerProjectComponent.java
+++ b/src/org/jetbrains/plugins/clojure/compiler/component/ClojureCompilerProjectComponent.java
@@ -12,6 +12,7 @@ import org.jetbrains.plugins.clojure.file.ClojureFileType;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author ilyas
@@ -29,18 +30,17 @@ public class ClojureCompilerProjectComponent implements ProjectComponent {
     compilerManager.addCompilableFileType(ClojureFileType.CLOJURE_FILE_TYPE);
 
     ClojureCompilerSettings settings = ClojureCompilerSettings.getInstance(myProject);
+    for (ClojureCompiler compiler : CompilerManager.getInstance(myProject).getCompilers(ClojureCompiler.class)) {
+      compilerManager.removeCompiler(compiler);
+    }
     if (settings.CLOJURE_BEFORE) {
-      for (ClojureCompiler compiler : CompilerManager.getInstance(myProject).getCompilers(ClojureCompiler.class)) {
-        CompilerManager.getInstance(myProject).removeCompiler(compiler);
-      }
-      HashSet<FileType> inputSet = new HashSet<FileType>(Arrays.asList(ClojureFileType.CLOJURE_FILE_TYPE, StdFileTypes.JAVA));
-      HashSet<FileType> outputSet = new HashSet<FileType>(Arrays.asList(StdFileTypes.JAVA, StdFileTypes.CLASS));
-      CompilerManager.getInstance(myProject).addTranslatingCompiler(new ClojureCompiler(myProject), inputSet, outputSet);
+      Set<FileType> inputSet = new HashSet<FileType>(Arrays.asList(ClojureFileType.CLOJURE_FILE_TYPE, StdFileTypes.JAVA));
+      Set<FileType> outputSet = new HashSet<FileType>(Arrays.asList(StdFileTypes.JAVA, StdFileTypes.CLASS));
+      compilerManager.addTranslatingCompiler(new ClojureCompiler(myProject), inputSet, outputSet);
     } else {
-      for (ClojureCompiler compiler : CompilerManager.getInstance(myProject).getCompilers(ClojureCompiler.class)) {
-        CompilerManager.getInstance(myProject).removeCompiler(compiler);
-      }
-      CompilerManager.getInstance(myProject).addCompiler(new ClojureCompiler(myProject));
+      compilerManager.addTranslatingCompiler(new ClojureCompiler(myProject),
+          new HashSet<FileType>(Arrays.asList(ClojureFileType.CLOJURE_FILE_TYPE, StdFileTypes.CLASS)),
+          new HashSet<FileType>(Arrays.asList(StdFileTypes.CLASS)));
     }
   }
 

--- a/src/org/jetbrains/plugins/clojure/psi/util/ClojurePsiUtil.java
+++ b/src/org/jetbrains/plugins/clojure/psi/util/ClojurePsiUtil.java
@@ -78,16 +78,20 @@ public class ClojurePsiUtil {
     return null;
   }
 
+  @Nullable
   public static ClKeywordImpl findNamespaceKeyByName(ClList ns, String keyName) {
-    final ClList list = ns.findFirstChildByClass(ClList.class);
-    if (list == null) return null;
-    for (PsiElement element : list.getChildren()) {
-      if (element instanceof ClKeywordImpl) {
-        ClKeywordImpl key = (ClKeywordImpl) element;
-        if (keyName.equals(key.getText())) {
-          return key;
+    ClList list = ns.findFirstChildByClass(ClList.class);
+
+    while (list != null) {
+      for (PsiElement element : list.getChildren()) {
+        if (element instanceof ClKeywordImpl) {
+          ClKeywordImpl key = (ClKeywordImpl) element;
+          if (keyName.equals(key.getText())) {
+            return key;
+          }
         }
       }
+      list = getNextSiblingByClass(list, ClList.class);
     }
     return null;
   }
@@ -99,6 +103,15 @@ public class ClojurePsiUtil {
       next = next.getNextSibling();
     }
     return next;
+  }
+
+  @Nullable
+  public static <T> T getNextSiblingByClass(PsiElement element, Class<T> aClass) {
+    PsiElement next = element.getNextSibling();
+    while (next != null && !aClass.isInstance(next)) {
+      next = next.getNextSibling();
+    }
+    return aClass.cast(next);
   }
 
   @NotNull


### PR DESCRIPTION
1. Compilation order was incorrect, causing Clojure files to be compiled before Java files.
2. AOT tests were incorrectly compiled to normal output directory.
3. findNamespaceKeyByName did not work correctly - it only identified a namespace as compilable if :gen-class was the first namespace key.

Fixes CLJ-97.
