### PR TITLE
CLJ-119 Rename refactoring doesn't take metadata into account

### DIFF
--- a/src/org/jetbrains/plugins/clojure/psi/impl/ClojureFileImpl.java
+++ b/src/org/jetbrains/plugins/clojure/psi/impl/ClojureFileImpl.java
@@ -81,10 +81,10 @@ public class ClojureFileImpl extends PsiFileBase implements ClojureFile {
   }
 
   public void setNamespace(String newNs) {
-    final ClList nsElem = getNamespaceElement();
+    final ClNs nsElem = getNamespaceElement();
     if (nsElem != null) {
       final ClSymbol first = nsElem.getFirstSymbol();
-      final PsiElement second = nsElem.getSecondNonLeafElement();
+      final PsiElement second = nsElem.getNameSymbol();
       if (first != null && second != null) {
         final ClojurePsiFactory factory = ClojurePsiFactory.getInstance(getProject());
         final ASTNode newNode = factory.createSymbolNodeFromText(newNs);


### PR DESCRIPTION
This is just a fix for CLJ-119 (Rename refactoring doesn't take metadata into account) I submitted the day before.
