### PR TITLE
CLJ-140 - Removed reference to ClojurePositionManagerFactory 

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -82,7 +82,6 @@
                                 implementationClass="org.jetbrains.plugins.clojure.documentation.ClojureDocumentationProvider"/>
     <renamePsiElementProcessor
         implementation="org.jetbrains.plugins.clojure.refactoring.rename.RenameClojureFileProcessor" order="first"/>
-    <debugger.positionManagerFactory implementation="org.jetbrains.plugins.clojure.debugger.ClojurePositionManagerFactory"/>
 
   </extensions>
 


### PR DESCRIPTION
When ClojurePositionManagerFactory is referenced from the plugin.xml in IntelliJ 11.x the debugger is no longer functional.  Removing this reference allows the debugger to resume functioning.
