### PR TITLE
Fixed CLJ-92 Compute rainbow braces color depending on background

### DIFF
--- a/src/org/jetbrains/plugins/clojure/editor/braceHighlighter/ClojureBraceAttributes.java
+++ b/src/org/jetbrains/plugins/clojure/editor/braceHighlighter/ClojureBraceAttributes.java
@@ -8,20 +8,25 @@ import java.awt.*;
  * @author ilyas
  */
 public abstract class ClojureBraceAttributes {
-  public static TextAttributes[] CLOJURE_BRACE_ATTRIBUTES =
+  private static final Color[] CLOJURE_BRACE_COLORS =
       {
-          new TextAttributes(Color.BLUE, null, null, null, 1), // 0
-          new TextAttributes(new Color(139, 0, 0), null, null, null, 1), // 10 red
-          new TextAttributes(new Color(47, 79, 47), null, null, null, 1),     // 1
-          new TextAttributes(new Color(199, 21, 133), null, null, null, 1), // 7 MediumVioletRed
-          new TextAttributes(new Color(85, 26, 139), null, null, null, 1), // 2 purple
-          new TextAttributes(Color.DARK_GRAY, null, null, null, 1),   // 3
-          new TextAttributes(new Color(0, 0, 128), null, null, null, 1), // 8 navy - blue
-          new TextAttributes(Color.RED, null, null, null, 1),             // 5
-          new TextAttributes(new Color(47, 79, 47), null, null, null, 1), // 6 Dark green
-          new TextAttributes(new Color(255, 100, 0), null, null, null, 1),   // 1 orange
-          new TextAttributes(new Color(139, 101, 8), null, null, null, 1), // 9 Dark golden
+          Color.BLUE, // 0
+          new Color(139, 0, 0), // 10 red
+          new Color(47, 79, 47),     // 1
+          new Color(199, 21, 133), // 7 MediumVioletRed
+          new Color(85, 26, 139), // 2 purple
+          Color.DARK_GRAY,   // 3
+          new Color(0, 0, 128), // 8 navy - blue
+          Color.RED,             // 5
+          new Color(47, 79, 47), // 6 Dark green
+          new Color(255, 100, 0),   // 1 orange
+          new Color(139, 101, 8), // 9 Dark golden
 
       };
 
+  public static TextAttributes getBraceAttributes(int level, Color background) {
+    Color braceColor = CLOJURE_BRACE_COLORS[level % CLOJURE_BRACE_COLORS.length];
+    Color adjustedBraceColor = new Color(braceColor.getRGB() ^ background.getRGB() ^ 0xFFFFFF);
+    return new TextAttributes(adjustedBraceColor, null, null, null, 1);
+  }
 }

--- a/src/org/jetbrains/plugins/clojure/editor/braceHighlighter/ClojureBraceHighlightingHandler.java
+++ b/src/org/jetbrains/plugins/clojure/editor/braceHighlighter/ClojureBraceHighlightingHandler.java
@@ -33,8 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
-import static org.jetbrains.plugins.clojure.editor.braceHighlighter.ClojureBraceAttributes.CLOJURE_BRACE_ATTRIBUTES;
-
 /**
  * @author ilyas
  */
@@ -128,7 +126,7 @@ public class ClojureBraceHighlightingHandler {
       while (!iterator.atEnd() && iterator.getEnd() <= endOffset) {
 
         if (ClojureTokenTypes.LEFT_PAREN.equals(iterator.getTokenType())) {
-          final TextAttributes attributes = CLOJURE_BRACE_ATTRIBUTES[level % CLOJURE_BRACE_ATTRIBUTES.length];
+          final TextAttributes attributes = ClojureBraceAttributes.getBraceAttributes(level, scheme.getDefaultBackground());
 
           myColorStack.push(attributes);
           final int start = iterator.getStart();


### PR DESCRIPTION
The color of rainbow braces is calculated using formula: default_color XOR backgound_color XOR 0xFFFFFF

Tested on "Default" and "Darkula" color schemes.
