### PR TITLE
evaluating last s-expression when the caret is positioned at EOF

### DIFF
--- a/src/org/jetbrains/plugins/clojure/psi/util/ClojurePsiUtil.java
+++ b/src/org/jetbrains/plugins/clojure/psi/util/ClojurePsiUtil.java
@@ -175,8 +175,8 @@ public class ClojurePsiUtil {
     CharSequence chars = editor.getDocument().getCharsSequence();
     int offset = editor.getCaretModel().getOffset();
     if (previous) {
-      if (offset == chars.length()) --offset; // we want the offset positioned at the last character, not at EOF
-      while (offset != 0 && offset < chars.length() && !anyOf(chars.charAt(offset), "]})")) {
+      if (offset >= chars.length()) offset = chars.length() - 1; // we want the offset positioned at the last character, not at EOF
+      while (offset != 0 && !anyOf(chars.charAt(offset), "]})")) {
         --offset;
       }
     }


### PR DESCRIPTION
To reproduce the bug:
- open a non-empty clojure file
- position the caret at the end of the file
- press ctrl-shift-H
- nothing happens.
