### PR TITLE
Don't leave a space after keywords in a collection

### DIFF
--- a/src/org/jetbrains/plugins/clojure/formatter/processors/ClojureSpacingProcessor.java
+++ b/src/org/jetbrains/plugins/clojure/formatter/processors/ClojureSpacingProcessor.java
@@ -4,6 +4,7 @@ import com.intellij.formatting.Block;
 import com.intellij.formatting.Spacing;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.plugins.clojure.formatter.ClojureBlock;
 import org.jetbrains.plugins.clojure.parser.ClojureElementTypes;
@@ -73,7 +74,7 @@ public class ClojureSpacingProcessor implements ClojureElementTypes {
     }
 
     // todo questionable: should be adjustable
-    if (psi1 instanceof ClKeyword) {
+    if (psi1 instanceof ClKeyword && !(psi2 instanceof LeafPsiElement)) {
       return NO_NEWLINE;
     }
 

--- a/test/org/jetbrains/plugins/clojure/editor/ClojureFormatterTest.java
+++ b/test/org/jetbrains/plugins/clojure/editor/ClojureFormatterTest.java
@@ -68,4 +68,8 @@ public class ClojureFormatterTest extends ClojureBaseTestCase {
   public void testNameApostrophe() {
     doFormat();
   }
+
+  public void testKeywordBeforeBrace() {
+    doFormat();
+  }
 }

--- a/testdata/formatter/keywordBeforeBrace.clj
+++ b/testdata/formatter/keywordBeforeBrace.clj
@@ -1,0 +1,2 @@
+(ns foo.bar
+  (:require [clojure.string :refer :all     ]))

--- a/testdata/formatter/keywordBeforeBrace.test
+++ b/testdata/formatter/keywordBeforeBrace.test
@@ -1,0 +1,2 @@
+(ns foo.bar
+  (:require [clojure.string :refer :all]))


### PR DESCRIPTION
This addresses #49.
