### PR TITLE
Remapped 'Run selected text in REPL' to avoid conficts, #CLJ-203

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -141,7 +141,7 @@
       <action id="org.jetbrains.plugins.clojure.repl.actions.RunSelectedTextAction"
               class="org.jetbrains.plugins.clojure.repl.actions.RunSelectedTextAction"
               text="Run selected text in REPL">
-        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift J"/>
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift K"/>
       </action>
 
       <action id="org.jetbrains.plugins.clojure.repl.actions.RunLastSExprAction"


### PR DESCRIPTION
By default, "Run selected text in REPL" (Ctrl+Shift+J) conflicts with Editor->"Join Lines".
I suggest to move it to Ctrl+Shift+K, this shortcut is not occupied and is close to other Clojure REPL shortcutrs (which are Ctrl+Shift+{L,H,G})
