### PR TITLE
Fix an assertReadAccessAllowed exception

### DIFF
--- a/src/java/org/jetbrains/plugins/clojure/psi/impl/ClojurePsiManager.java
+++ b/src/java/org/jetbrains/plugins/clojure/psi/impl/ClojurePsiManager.java
@@ -3,12 +3,9 @@ package org.jetbrains.plugins.clojure.psi.impl;
 import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.startup.StartupManager;
-import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.plugins.clojure.psi.stubs.ClojureShortNamesCache;
 import org.jetbrains.plugins.clojure.file.ClojureFileType;
 
 /**
@@ -34,7 +31,13 @@ public class ClojurePsiManager implements ProjectComponent {
   }
 
   public void initComponent() {
-    myDummyFile = PsiFileFactory.getInstance(myProject).createFileFromText("dummy." + ClojureFileType.CLOJURE_FILE_TYPE.getDefaultExtension(), "");
+    ApplicationManager.getApplication().runReadAction(new Runnable() {
+      public void run() {
+        final String dummyFn = "dummy." + ClojureFileType.CLOJURE_FILE_TYPE.getDefaultExtension();
+        myDummyFile = PsiFileFactory.getInstance(myProject)
+            .createFileFromText(dummyFn, ClojureFileType.CLOJURE_FILE_TYPE, "");
+      }
+    });
   }
 
   public void disposeComponent() {


### PR DESCRIPTION
The `la-clojure` plugin has been generating assertion Throwables in my [nightly IJ](https://github.com/JetBrains/intellij-community/commit/b913f1cd) builds for a few days now. The assertion text is extremely helpful, and it was a quick fix:

> Read access is allowed from event dispatch thread or inside read-action only
> (see com.intellij.openapi.application.Application.runReadAction())

It even appears from the unused imports(!) in the file that the `PsiManager` once upon a time did use `ApplicationManager`, so that was further confirmation that this is probably the correct fix.

The same number of tests are broken after my fix as were broken before it.
