### PR TITLE
IntelliJ 14 is now at build 139.144.2

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -17,7 +17,7 @@
     Inc.
   </vendor>
 
-  <idea-version since-build="138.1696" until-build="139.0"/>
+  <idea-version since-build="138.1696" until-build="140.0"/>
 
   <depends optional="true" config-file="copyright.xml">com.intellij.copyright</depends>
 


### PR DESCRIPTION
The plugin works well with IntelliJ 14 but currently the installation is prevented because the plugin is limited to build 139.0! I changed this to 140.0 locally and everything still seems to work fine.
